### PR TITLE
fix/ITPL-16102: use lodash instead of es6 features

### DIFF
--- a/gex.js
+++ b/gex.js
@@ -6,11 +6,17 @@
   var root = this
   var previous_gex = root.gex
 
+  var has_require = typeof require !== 'undefined'
+
+  var _ = root._ || has_require && require('lodash')
+  if( !_ )
+    throw new Error('gex requires underscore, see http://underscorejs.org')
+  
   function Gex(gexspec) {
     var self = this
 
     function dodgy(obj) {
-      return null == obj || void 0 == obj || Number.isNaN(obj)
+      return null == obj || void 0 == obj || _.isNaN(obj)
     }
 
     function clean(gexexp) {
@@ -94,7 +100,7 @@
         return new RegExp(gs)
       } else {
         var gexstrs = Object.keys(gexmap)
-        return 1 == gexstrs.length ? gexmap[gexstrs[0]] : { ...gexmap }
+        return 1 == gexstrs.length ? gexmap[gexstrs[0]] : _.clone(gexmap)
       }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1161,10 +1161,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "http://localhost:4873/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "log-driver": {
       "version": "1.2.7",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "Richard Rodger (http://richardrodger.com/)"
   ],
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "lodash": "^4.17.20"
+  },
   "main": "gex.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Issue: User cannot login in IE 11 due login response being treated as file. The reason for this is vendors.js has a syntactical error as gex is not being transpiled to ES5 and thus the browser still expects a file and treats the login response as a file.

Solution: Update `gex` to use lodash instead of utilising ES6 features such as rest and spread.

Justification for solution:
Of course ideally we simply tell Babel to transpile the file. However this came with unexpected errors where `this` in the gex.js file was undefined. Was not able to determine why this was happening. As 5.6.0 is on a time crunch, the quickest solution is to simply fork gex, update the code to use lodash, then update modules to use this forked version